### PR TITLE
Add test-logger plugin to print ITs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id "net.ltgt.errorprone" version "2.0.2" apply false
     id "io.freefair.lombok" version "5.3.3.3" apply false
     id "jacoco"
+    id 'com.adarshr.test-logger' version '2.1.1'
 }
 
 subprojects {

--- a/butler-server/build.gradle
+++ b/butler-server/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'org.hidetake.ssh' version '2.10.1'
     id 'java'
     id 'com.avast.gradle.docker-compose' version '0.16.4'
+    id 'com.adarshr.test-logger'
 }
 
 configurations {


### PR DESCRIPTION
Rationale:
integrationTest cases are not printed on the console.

This change brings https://github.com/radarsh/gradle-test-logger-plugin
so that it is nicely printed out e.g. during gh actions.

We are using 2.1.1 as apparently recent 3.2 has issues and can fail.
